### PR TITLE
Fix broken configs for "remote" and "bare" repos.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,7 +11,7 @@ go_repositories()
 git_repository(
   name = "ws_remote",
   remote = "https://github.com/laramiel/bazel-example-golang-remote.git",
-  commit = "8f2e405",
+  commit = "4a9199b",
 )
 
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,7 @@ git_repository(
 
 
 BARE_BUILD = """
-load("@bazel_tools//tools/build_rules/go:def.bzl", "go_prefix", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library")
 
 go_prefix("github.com/laramiel/bazel-example-golang-bare")
 


### PR DESCRIPTION
- Update "bazel-example-golang-remote.git" git_repository commit to recently fixed version.
- Complete the recent incomplete update from "bazel_tools//tools/build_rules/" to "io_bazel_rules_go//".

Prior to these changes, neither "bazel run :remote" nor "bazel run :bare" work.  This fixes both builds.
